### PR TITLE
enable method dispatch compatibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ### enhancements
 
+* Enable method dispatch compatibility in `pc()` and `ops()` generics via `...` (#43).
+
 * Improve handling of large-scale inputs (#33).
 
 # pc 0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 # pc 0.2
 
-### enhancements
+### new
 
 * Add Loess Plateau precipitation–soil moisture–NDVI case dataset (#41).
 
 * Support linear trend removal for spatial cross-sectional data (#36).
+
+### enhancements
 
 * Improve handling of large-scale inputs (#33).
 

--- a/R/ops.R
+++ b/R/ops.R
@@ -1,6 +1,6 @@
 .ops_ts = \(data, target, source, E = 3:5, k = E, tau = 1, style = 1, lib = NULL, pred = NULL,
             maximize = c("dark", "positive", "negative"), dist.metric = c("euclidean", "manhattan", "maximum"), 
-            zero.tolerance = max(k), relative = TRUE, weighted = TRUE, threads = length(E), higher.parallel = TRUE, h = 0) {
+            zero.tolerance = max(k), relative = TRUE, weighted = TRUE, threads = length(E), higher.parallel = TRUE, h = 0, ...) {
   maximize = match.arg(maximize)
   dist.metric = match.arg(dist.metric)
   dlist = .validate_var(data, target, source)
@@ -14,7 +14,7 @@
 
 .ops_lattice = \(data, target, source, E = 3:5, k = E+1, tau = 1, style = 1, lib = NULL, pred = NULL, 
                  maximize = c("dark", "positive", "negative"), dist.metric = c("euclidean", "manhattan", "maximum"), 
-                 zero.tolerance = max(k), relative = TRUE, weighted = TRUE, threads = length(E), higher.parallel = TRUE, detrend = FALSE, nb = NULL) {
+                 zero.tolerance = max(k), relative = TRUE, weighted = TRUE, threads = length(E), higher.parallel = TRUE, detrend = FALSE, nb = NULL, ...) {
   if (is.null(nb)) nb = sdsfun::spdep_nb(data)
   maximize = match.arg(maximize)
   dist.metric = match.arg(dist.metric)
@@ -29,7 +29,7 @@
 
 .ops_grid = \(data, target, source, E = 3:5, k = E+1, tau = 1, style = 1, lib = NULL, pred = NULL,
               maximize = c("positive", "negative", "dark"), dist.metric = c("euclidean", "manhattan", "maximum"), 
-              zero.tolerance = max(k), relative = TRUE, weighted = TRUE, threads = length(E), higher.parallel = TRUE, detrend = FALSE) {
+              zero.tolerance = max(k), relative = TRUE, weighted = TRUE, threads = length(E), higher.parallel = TRUE, detrend = FALSE, ...) {
   maximize = match.arg(maximize)
   dist.metric = match.arg(dist.metric)
   dlist = .validate_var(data, target, source, detrend)

--- a/R/pc.R
+++ b/R/pc.R
@@ -1,6 +1,6 @@
 .pc_ts = \(data, target, source, libsizes = NULL, E = 3, k = E, tau = 1, style = 1, lib = NULL, pred = NULL, boot = 99,
            random = TRUE, seed = 42L, dist.metric = c("euclidean", "manhattan", "maximum"), zero.tolerance = max(k),
-           relative = TRUE, weighted = TRUE, threads = length(libsizes), higher.parallel = TRUE, verbose = TRUE, h = 0) {
+           relative = TRUE, weighted = TRUE, threads = length(libsizes), higher.parallel = TRUE, verbose = TRUE, h = 0, ...) {
   dist.metric = match.arg(dist.metric)
   dlist = .validate_var(data, target, source)
   tv = dlist[[1]]; sv = dlist[[2]]
@@ -17,8 +17,8 @@
 }
 
 .pc_lattice = \(data, target, source, libsizes = NULL, E = 3, k = E+1, tau = 1, style = 1, lib = NULL, pred = NULL, boot = 99,
-                random = TRUE, seed = 42L, dist.metric = c("euclidean", "manhattan", "maximum"), zero.tolerance = max(k),
-                relative = TRUE, weighted = TRUE, threads = length(libsizes), higher.parallel = TRUE, verbose = TRUE, detrend = FALSE, nb = NULL) {
+                random = TRUE, seed = 42L, dist.metric = c("euclidean", "manhattan", "maximum"), zero.tolerance = max(k), 
+                relative = TRUE, weighted = TRUE, threads = length(libsizes), higher.parallel = TRUE, verbose = TRUE, detrend = FALSE, nb = NULL, ...) {
   if (is.null(nb)) nb = sdsfun::spdep_nb(data)
   dist.metric = match.arg(dist.metric)
   dlist = .validate_var(data, target, source, detrend)
@@ -36,8 +36,8 @@
 }
 
 .pc_grid = \(data, target, source, libsizes = NULL, E = 3, k = E+1, tau = 1, style = 1, lib = NULL, pred = NULL, boot = 99,
-             random = TRUE, seed = 42L, dist.metric = c("euclidean", "manhattan", "maximum"), zero.tolerance = max(k),
-             relative = TRUE, weighted = TRUE, threads = length(libsizes), higher.parallel = TRUE, verbose = TRUE, detrend = FALSE) {
+             random = TRUE, seed = 42L, dist.metric = c("euclidean", "manhattan", "maximum"), zero.tolerance = max(k), 
+             relative = TRUE, weighted = TRUE, threads = length(libsizes), higher.parallel = TRUE, verbose = TRUE, detrend = FALSE, ...) {
   dist.metric = match.arg(dist.metric)
   dlist = .validate_var(data, target, source, detrend)
   tv = dlist[[1]]; sv = dlist[[2]]

--- a/R/pc.R
+++ b/R/pc.R
@@ -80,6 +80,7 @@
 #' @param h (optional) Prediction horizon.
 #' @param detrend (optional) Whether to remove the linear trend.
 #' @param nb (optional) Neighbours list.
+#' @param ... Additional arguments to absorb unused inputs in method dispatch.
 #'
 #' @return A list (when `libsizes` is `NULL`) or data.frame.
 #' If `libsizes` is `NULL`, a list with two components is returned:

--- a/man/ops.Rd
+++ b/man/ops.Rd
@@ -24,7 +24,8 @@
   weighted = TRUE,
   threads = length(E),
   higher.parallel = TRUE,
-  h = 0
+  h = 0,
+  ...
 )
 
 \S4method{ops}{sf}(
@@ -45,7 +46,8 @@
   threads = length(E),
   higher.parallel = TRUE,
   detrend = FALSE,
-  nb = NULL
+  nb = NULL,
+  ...
 )
 
 \S4method{ops}{SpatRaster}(
@@ -65,7 +67,8 @@
   weighted = TRUE,
   threads = length(E),
   higher.parallel = TRUE,
-  detrend = FALSE
+  detrend = FALSE,
+  ...
 )
 }
 \arguments{
@@ -102,6 +105,8 @@
 \item{higher.parallel}{(optional) Whether to use a higher level of parallelism.}
 
 \item{h}{(optional) Prediction horizon.}
+
+\item{...}{Additional arguments to absorb unused inputs in method dispatch.}
 
 \item{detrend}{(optional) Whether to remove the linear trend.}
 

--- a/man/pc.Rd
+++ b/man/pc.Rd
@@ -28,7 +28,8 @@
   threads = length(libsizes),
   higher.parallel = TRUE,
   verbose = TRUE,
-  h = 0
+  h = 0,
+  ...
 )
 
 \S4method{pc}{sf}(
@@ -53,7 +54,8 @@
   higher.parallel = TRUE,
   verbose = TRUE,
   detrend = FALSE,
-  nb = NULL
+  nb = NULL,
+  ...
 )
 
 \S4method{pc}{SpatRaster}(
@@ -77,7 +79,8 @@
   threads = length(libsizes),
   higher.parallel = TRUE,
   verbose = TRUE,
-  detrend = FALSE
+  detrend = FALSE,
+  ...
 )
 }
 \arguments{
@@ -122,6 +125,8 @@
 \item{verbose}{(optional) Whether to show the progress bar.}
 
 \item{h}{(optional) Prediction horizon.}
+
+\item{...}{Additional arguments to absorb unused inputs in method dispatch.}
 
 \item{detrend}{(optional) Whether to remove the linear trend.}
 


### PR DESCRIPTION
This PR adds `...` to `pc()` and `ops()` generics to absorb unused arguments during method dispatch. Prevent errors from mismatched argument signatures across methods without changing user-facing behavior.