### PR TITLE
correct pattern causality logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@
 
 * Improve handling of large-scale inputs (#33).
 
+### bug fixes
+
+* Fix unintended CCM-style xmap behavior in pattern causality estimation (#52).
+
 # pc 0.1
 
 * First stable release (#24).

--- a/R/pc.R
+++ b/R/pc.R
@@ -83,7 +83,7 @@
 #'
 #' @examples
 #' columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
-#' pc::pc(columbus, 1, 3, E = 3, k = 9, threads = 1)
+#' pc::pc(columbus, 1, 3, E = 3, k = 5, threads = 1)
 #'
 methods::setMethod("pc", "data.frame", .pc_ts)
 

--- a/man/pc.Rd
+++ b/man/pc.Rd
@@ -145,7 +145,7 @@ Pattern Causality
 }
 \examples{
 columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
-pc::pc(columbus, 1, 3, E = 3, k = 9, threads = 1)
+pc::pc(columbus, 1, 3, E = 3, k = 5, threads = 1)
 
 }
 \references{

--- a/src/PC.cpp
+++ b/src/PC.cpp
@@ -1155,24 +1155,24 @@ Rcpp::List RcppPCops(
             if (nb.isNotNull()) 
             {
                 Mx = pc::embed::embed(
-                    tg, nb_std, Ei, taui, static_cast<size_t>(std::abs(style)));
-                My = pc::embed::embed(
                     sg, nb_std, Ei, taui, static_cast<size_t>(std::abs(style)));
+                My = pc::embed::embed(
+                    tg, nb_std, Ei, taui, static_cast<size_t>(std::abs(style)));
             } 
             else if (nrows.isNotNull())
             {   
                 Mx = pc::embed::embed(
-                    tm, Ei, taui, static_cast<size_t>(std::abs(style)));
+                    sm, Ei, taui, static_cast<size_t>(std::abs(style)));
 
                 My = pc::embed::embed(
-                    sm, Ei, taui, static_cast<size_t>(std::abs(style)));
+                    tm, Ei, taui, static_cast<size_t>(std::abs(style)));
             }
             else  
             {
                 Mx = pc::embed::embed(
-                    tg, Ei, taui, static_cast<size_t>(std::abs(style)));
-                My = pc::embed::embed(
                     sg, Ei, taui, static_cast<size_t>(std::abs(style)));
+                My = pc::embed::embed(
+                    tg, Ei, taui, static_cast<size_t>(std::abs(style)));
             }
             
             pc::symdync::PatternCausalityRes res;

--- a/src/PC.cpp
+++ b/src/PC.cpp
@@ -451,9 +451,9 @@ Rcpp::DataFrame RcppPCboot(
     else  
     {
         Mx = pc::embed::embed(
-            tg, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
+            sg, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
         My = pc::embed::embed(
-            sg, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
+            tg, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
 
         size_t max_E = *std::max_element(E_std.begin(), E_std.end());
         size_t max_tau = *std::max_element(tau_std.begin(), tau_std.end());

--- a/src/PC.cpp
+++ b/src/PC.cpp
@@ -430,23 +430,23 @@ Rcpp::DataFrame RcppPCboot(
         // Convert Rcpp::List to std::vector<std::vector<size_t>>
         std::vector<std::vector<size_t>> nb_std = pc::convert::nb2std(nb.get());
         Mx = pc::embed::embed(
-            tg, nb_std, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
+            sg, nb_std, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
         My = pc::embed::embed(
-            sg, nb_std, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
+            tg, nb_std, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
     } 
     else if (nrows.isNotNull())
     {   
         size_t n_rows = static_cast<size_t>(std::abs(Rcpp::as<int>(nrows)));
 
-        std::vector<std::vector<double>> tm = 
-            pc::embed::gridVec2Mat(tg, n_rows);
-        Mx = pc::embed::embed(
-            tm, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
-
         std::vector<std::vector<double>> sm = 
             pc::embed::gridVec2Mat(sg, n_rows);
+        Mx = pc::embed::embed(
+            sm, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
+
+        std::vector<std::vector<double>> tm = 
+            pc::embed::gridVec2Mat(tg, n_rows);
         My = pc::embed::embed(
-            sm, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
+            tm, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
     }
     else  
     {

--- a/src/PC.cpp
+++ b/src/PC.cpp
@@ -104,30 +104,30 @@ Rcpp::List RcppPC(
         // Convert Rcpp::List to std::vector<std::vector<size_t>>
         std::vector<std::vector<size_t>> nb_std = pc::convert::nb2std(nb.get());
         Mx = pc::embed::embed(
-            tg, nb_std, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
+            sg, nb_std, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
         My = pc::embed::embed(
-            sg, nb_std, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
+            tg, nb_std, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
     } 
     else if (nrows.isNotNull())
     {   
         size_t n_rows = static_cast<size_t>(std::abs(Rcpp::as<int>(nrows)));
 
-        std::vector<std::vector<double>> tm = 
-            pc::embed::gridVec2Mat(tg, n_rows);
-        Mx = pc::embed::embed(
-            tm, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
-
         std::vector<std::vector<double>> sm = 
             pc::embed::gridVec2Mat(sg, n_rows);
-        My = pc::embed::embed(
+        Mx = pc::embed::embed(
             sm, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
+
+        std::vector<std::vector<double>> tm = 
+            pc::embed::gridVec2Mat(tg, n_rows);
+        My = pc::embed::embed(
+            tm, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
     }
     else  
     {
         Mx = pc::embed::embed(
-            tg, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
+            sg, E_std[0], tau_std[0], static_cast<size_t>(std::abs(style)));
         My = pc::embed::embed(
-            sg, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
+            tg, E_std[1], tau_std[1], static_cast<size_t>(std::abs(style)));
 
         size_t max_E = *std::max_element(E_std.begin(), E_std.end());
         size_t max_tau = *std::max_element(tau_std.begin(), tau_std.end());

--- a/src/PC.cpp
+++ b/src/PC.cpp
@@ -1071,24 +1071,24 @@ Rcpp::List RcppPCops(
             if (nb.isNotNull()) 
             {
                 Mx = pc::embed::embed(
-                    tg, nb_std, Ei, taui, static_cast<size_t>(std::abs(style)));
-                My = pc::embed::embed(
                     sg, nb_std, Ei, taui, static_cast<size_t>(std::abs(style)));
+                My = pc::embed::embed(
+                    tg, nb_std, Ei, taui, static_cast<size_t>(std::abs(style)));
             } 
             else if (nrows.isNotNull())
             {   
                 Mx = pc::embed::embed(
-                    tm, Ei, taui, static_cast<size_t>(std::abs(style)));
+                    sm, Ei, taui, static_cast<size_t>(std::abs(style)));
 
                 My = pc::embed::embed(
-                    sm, Ei, taui, static_cast<size_t>(std::abs(style)));
+                    tm, Ei, taui, static_cast<size_t>(std::abs(style)));
             }
             else  
             {
                 Mx = pc::embed::embed(
-                    tg, Ei, taui, static_cast<size_t>(std::abs(style)));
-                My = pc::embed::embed(
                     sg, Ei, taui, static_cast<size_t>(std::abs(style)));
+                My = pc::embed::embed(
+                    tg, Ei, taui, static_cast<size_t>(std::abs(style)));
             }
 
             // --- Perform Pattern Causality Analysis ---


### PR DESCRIPTION
This PR corrects the pattern causality implementation previously following a CCM-style cross mapping (`xmap`) scheme.
The updated implementation now adheres to a directional prediction framework, ensuring consistency with the intended causality definition as described in <https://doi.org/10.1073/pnas.1918269117>,

```
We introduce a method that unveils the structure of complex systems
through time series data. Thus, taking a pair of time series and testing it for
causality, we check whether, how much, and in which direction X causes Y. In
this regard, first, we reconstruct the shadow attractors, i.e., their time
delayed representations on at least a two-dimensional space. Finally,we
test X’s ability to predict Y’s values.The better the prediction accuracy is the
stronger the causality from X to Y.
```
